### PR TITLE
[Refactor] 테스트셋 업로드를 위한 사진 다중 업로드 구현

### DIFF
--- a/src/main/java/barcode/phomate/PhomateApplication.java
+++ b/src/main/java/barcode/phomate/PhomateApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAsync
+@EnableScheduling
 public class PhomateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/barcode/phomate/domain/photo/application/PhotoCommitJobPoller.java
+++ b/src/main/java/barcode/phomate/domain/photo/application/PhotoCommitJobPoller.java
@@ -1,0 +1,69 @@
+package barcode.phomate.domain.photo.application;
+
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJob;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Scheduled poller that drives the photo commit job pipeline.
+ *
+ * <p>Two independent schedules run here:
+ * <ul>
+ *   <li>{@link #poll()} — every 2 s, claims PENDING jobs and processes each
+ *       one in its own transaction via {@link PhotoCommitJobService}.</li>
+ *   <li>{@link #sweepStuck()} — every 60 s, resets PROCESSING jobs that have
+ *       been stuck beyond {@value #STUCK_THRESHOLD_MINUTES} minutes back to
+ *       PENDING so they can be retried.</li>
+ * </ul>
+ *
+ * <p>Each job is processed in a separate transaction (via
+ * {@link PhotoCommitJobService#processOne}), so a failure in one job never
+ * affects the others claimed in the same poll cycle.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PhotoCommitJobPoller {
+
+    private static final int  POLL_BATCH_SIZE         = 10;
+    private static final int  SWEEP_LIMIT             = 50;
+    private static final long STUCK_THRESHOLD_MINUTES = 10L;
+
+    private final PhotoCommitJobService jobService;
+
+    /**
+     * Claims up to {@value #POLL_BATCH_SIZE} PENDING jobs and processes each
+     * sequentially. Runs every 2 seconds with a fixed delay between completions
+     * to avoid overlapping executions.
+     */
+    @Scheduled(fixedDelay = 2_000)
+    public void poll() {
+        List<PhotoCommitJob> claimed = jobService.claimPending(POLL_BATCH_SIZE);
+        if (claimed.isEmpty()) return;
+
+        log.info("[POLLER] claimed {} jobs", claimed.size());
+        for (PhotoCommitJob job : claimed) {
+            jobService.processOne(job.getId());
+        }
+    }
+
+    /**
+     * Finds PROCESSING jobs whose {@code updated_at} is older than
+     * {@value #STUCK_THRESHOLD_MINUTES} minutes and resets them to PENDING.
+     * Runs every 60 seconds.
+     */
+    @Scheduled(fixedDelay = 60_000)
+    public void sweepStuck() {
+        LocalDateTime threshold = LocalDateTime.now().minus(Duration.ofMinutes(STUCK_THRESHOLD_MINUTES));
+        int recovered = jobService.sweepStuck(threshold, SWEEP_LIMIT);
+        if (recovered > 0) {
+            log.info("[SWEEP] reset {} stuck jobs to PENDING", recovered);
+        }
+    }
+}

--- a/src/main/java/barcode/phomate/domain/photo/application/PhotoCommitJobProcessor.java
+++ b/src/main/java/barcode/phomate/domain/photo/application/PhotoCommitJobProcessor.java
@@ -1,0 +1,146 @@
+package barcode.phomate.domain.photo.application;
+
+import barcode.phomate.domain.photo.domain.entity.Photo;
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJob;
+import barcode.phomate.domain.photo.domain.repository.PhotoRepository;
+import barcode.phomate.global.exception.ForbiddenException;
+import barcode.phomate.global.exception.NotFoundException;
+import barcode.phomate.global.fastapi.application.EmbeddingAsyncService;
+import barcode.phomate.global.fastapi.dto.EmbedRequestDTO;
+import barcode.phomate.global.s3.application.S3StorageService;
+import barcode.phomate.global.tx.AfterCommitExecutor;
+import barcode.phomate.global.util.ImageResizeUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+import java.io.IOException;
+import java.time.ZoneId;
+
+/**
+ * Executes the per-photo S3 processing pipeline for a single {@link PhotoCommitJob}.
+ *
+ * <p>Runs in its own {@code REQUIRES_NEW} transaction so that photo-side changes
+ * commit (or roll back) independently of the job-state transaction managed by
+ * {@link PhotoCommitJobService}. This ensures that a processing failure never
+ * contaminates the job status update.
+ *
+ * <p><strong>Idempotency</strong>: thumbnail and preview S3 keys are derived
+ * deterministically from {@code photo.id} ({@code photos/{id}/t.jpg},
+ * {@code photos/{id}/p.jpg}). Re-processing the same job simply overwrites the
+ * same objects, making retries safe.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoCommitJobProcessor {
+
+    private final PhotoRepository          photoRepository;
+    private final S3StorageService         s3StorageService;
+    private final EmbeddingAsyncService    embeddingAsyncService;
+    private final AfterCommitExecutor      afterCommitExecutor;
+
+    @Value("${app.cdn.base-url}")
+    private String cloudFrontBaseUrl;
+
+    private static final String CACHE_CONTROL  = "public, max-age=31536000";
+    private static final int    THUMB_SHORT_PX = 320;
+    private static final int    PREVIEW_SHORT_PX = 1_080;
+    private static final float  THUMB_QUALITY  = 0.82f;
+    private static final float  PREVIEW_QUALITY = 0.85f;
+
+    /**
+     * Downloads the original image from S3, generates thumbnail and preview
+     * JPEGs, uploads them, updates the {@link Photo} entity, and enqueues an
+     * embedding trigger to run after this transaction commits.
+     *
+     * @param job  the job to process; only its fields are read — the entity is
+     *             not mutated here
+     * @throws NotFoundException      if the associated photo no longer exists in the DB
+     * @throws ForbiddenException     if {@code job.memberId} does not own the photo
+     * @throws IllegalStateException  if the client-supplied ETag does not match S3,
+     *                                or if the image cannot be decoded/resized
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void process(PhotoCommitJob job) {
+        Photo photo = photoRepository.findById(job.getPhotoId())
+                .orElseThrow(() -> new NotFoundException("사진을 찾을 수 없습니다."));
+
+        if (!photo.getMember().getId().equals(job.getMemberId())) {
+            throw new ForbiddenException("권한이 없습니다.");
+        }
+
+        // ETag integrity check (optional — skipped when etag is blank)
+        if (job.getEtag() != null && !job.getEtag().isBlank()) {
+            HeadObjectResponse head = s3StorageService.headObject(job.getOriginalKey());
+            String serverEtag = normalizeEtag(head.eTag());
+            String clientEtag = normalizeEtag(job.getEtag());
+            if (serverEtag != null && clientEtag != null && !serverEtag.equals(clientEtag)) {
+                throw new IllegalStateException("ETag mismatch: 업로드된 파일이 다릅니다.");
+            }
+        }
+
+        byte[] originalBytes = s3StorageService.getObjectBytes(job.getOriginalKey());
+
+        byte[] thumbJpg;
+        byte[] previewJpg;
+        try {
+            thumbJpg   = ImageResizeUtil.toJpgResized(originalBytes, THUMB_SHORT_PX,   THUMB_QUALITY);
+            previewJpg = ImageResizeUtil.toJpgResized(originalBytes, PREVIEW_SHORT_PX, PREVIEW_QUALITY);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to decode/resize image.", e);
+        }
+
+        // Deterministic keys derived from photo ID → overwrite-safe on retry
+        String prefix     = "photos/" + photo.getId();
+        String thumbKey   = prefix + "/t.jpg";
+        String previewKey = prefix + "/p.jpg";
+
+        s3StorageService.putBytes(thumbKey,   thumbJpg,   "image/jpeg", CACHE_CONTROL);
+        s3StorageService.putBytes(previewKey, previewJpg, "image/jpeg", CACHE_CONTROL);
+
+        photo.updateImageKeys(prefix, job.getOriginalKey(), thumbKey, previewKey);
+
+        String previewUrl  = cloudFrontBaseUrl + "/" + previewKey;
+        long   createdAtMs = photo.getCreatedAt()
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli();
+
+        String text = (photo.getDescription() == null) ? "" : photo.getDescription().trim();
+
+        EmbedRequestDTO embedReq = new EmbedRequestDTO(
+                photo.getId(), job.getMemberId(), previewUrl, text, createdAtMs);
+
+        // Trigger embedding only after this REQUIRES_NEW transaction commits
+        afterCommitExecutor.run(() -> {
+            try {
+                embeddingAsyncService.embedPhoto(embedReq);
+            } catch (Exception e) {
+                log.error("[EMBED] enqueue failed photoId={} err={}", photo.getId(), e.getMessage(), e);
+            }
+        });
+
+        log.info("[PROCESSOR] done photoId={} batchId={}", photo.getId(), job.getBatchId());
+    }
+
+    /**
+     * Strips surrounding double-quotes from an ETag value so that
+     * {@code "abc"} and {@code abc} compare equal.
+     *
+     * @param etag raw ETag string, may be null
+     * @return unquoted ETag, or null if the result would be blank
+     */
+    private String normalizeEtag(String etag) {
+        if (etag == null) return null;
+        String t = etag.trim();
+        if (t.startsWith("\"") && t.endsWith("\"") && t.length() >= 2) {
+            t = t.substring(1, t.length() - 1);
+        }
+        return t.isBlank() ? null : t;
+    }
+}

--- a/src/main/java/barcode/phomate/domain/photo/application/PhotoCommitJobService.java
+++ b/src/main/java/barcode/phomate/domain/photo/application/PhotoCommitJobService.java
@@ -1,0 +1,95 @@
+package barcode.phomate.domain.photo.application;
+
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJob;
+import barcode.phomate.domain.photo.domain.repository.PhotoCommitJobRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Manages the lifecycle of {@link PhotoCommitJob} entities within the
+ * job-table-based async upload pipeline.
+ *
+ * <p>Each public method runs in its own transaction so that the job-state
+ * update (claim / done / retry / FAILED) is committed independently of the
+ * photo-processing work handled by {@link PhotoCommitJobProcessor}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoCommitJobService {
+
+    static final int  MAX_RETRIES     = 3;
+    static final long BACKOFF_BASE_MS = 5_000L;
+
+    private final PhotoCommitJobRepository repository;
+    private final PhotoCommitJobProcessor  processor;
+
+    /**
+     * Atomically claims up to {@code limit} PENDING jobs by marking them
+     * PROCESSING. Uses {@code FOR UPDATE SKIP LOCKED} to prevent concurrent
+     * pollers from picking the same rows.
+     *
+     * @param limit maximum number of jobs to claim; must be &gt; 0
+     * @return list of now-PROCESSING jobs (may be empty if nothing is due)
+     */
+    @Transactional
+    public List<PhotoCommitJob> claimPending(int limit) {
+        List<PhotoCommitJob> jobs = repository.findPendingForUpdate(limit);
+        jobs.forEach(PhotoCommitJob::markProcessing);
+        return jobs;
+    }
+
+    /**
+     * Processes a single job in its own transaction.
+     *
+     * <p>Delegates the actual S3 work to {@link PhotoCommitJobProcessor#process},
+     * which runs in a nested {@code REQUIRES_NEW} transaction. On success the job
+     * is marked DONE. On failure {@code retry_count} is incremented and the job
+     * is either re-scheduled (PENDING with exponential back-off) or permanently
+     * marked FAILED when {@value MAX_RETRIES} attempts have been exhausted.
+     *
+     * @param jobId ID of an existing job; must be in PROCESSING state
+     * @throws IllegalStateException if {@code jobId} does not exist
+     */
+    @Transactional
+    public void processOne(Long jobId) {
+        PhotoCommitJob job = repository.findById(jobId)
+                .orElseThrow(() -> new IllegalStateException("Job not found: " + jobId));
+        try {
+            processor.process(job);
+            job.markDone();
+            log.info("[JOB] DONE jobId={} photoId={}", jobId, job.getPhotoId());
+        } catch (Exception e) {
+            log.warn("[JOB] attempt failed jobId={} photoId={} retryCount={} err={}",
+                    jobId, job.getPhotoId(), job.getRetryCount() + 1, e.getMessage());
+            job.scheduleRetry(e.getMessage(), MAX_RETRIES, BACKOFF_BASE_MS);
+            if (job.getStatus().name().equals("FAILED")) {
+                log.error("[JOB] permanently FAILED jobId={} photoId={}", jobId, job.getPhotoId());
+            }
+        }
+    }
+
+    /**
+     * Recovers PROCESSING jobs that have been stuck beyond {@code threshold}
+     * by resetting them to PENDING. This handles the case where a worker node
+     * died mid-flight and never committed a final status.
+     *
+     * @param threshold  jobs last updated before this instant are considered stuck
+     * @param limit      maximum number of stuck jobs to recover in one sweep
+     * @return number of jobs reset to PENDING
+     */
+    @Transactional
+    public int sweepStuck(LocalDateTime threshold, int limit) {
+        List<PhotoCommitJob> stuck = repository.findStuckProcessingForUpdate(threshold, limit);
+        stuck.forEach(PhotoCommitJob::resetToPending);
+        if (!stuck.isEmpty()) {
+            log.warn("[SWEEP] recovered {} stuck jobs older than {}", stuck.size(), threshold);
+        }
+        return stuck.size();
+    }
+}

--- a/src/main/java/barcode/phomate/domain/photo/application/PhotoUploadService.java
+++ b/src/main/java/barcode/phomate/domain/photo/application/PhotoUploadService.java
@@ -3,24 +3,19 @@ package barcode.phomate.domain.photo.application;
 import barcode.phomate.domain.member.domain.entity.Member;
 import barcode.phomate.domain.member.domain.repository.MemberRepository;
 import barcode.phomate.domain.photo.domain.entity.Photo;
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJob;
+import barcode.phomate.domain.photo.domain.repository.PhotoCommitJobRepository;
 import barcode.phomate.domain.photo.domain.repository.PhotoRepository;
 import barcode.phomate.domain.photo.dto.*;
 import barcode.phomate.global.exception.ForbiddenException;
 import barcode.phomate.global.exception.NotFoundException;
-import barcode.phomate.global.fastapi.application.EmbeddingAsyncService;
-import barcode.phomate.global.fastapi.dto.EmbedRequestDTO;
 import barcode.phomate.global.s3.application.S3StorageService;
-import barcode.phomate.global.tx.AfterCommitExecutor;
-import barcode.phomate.global.util.ImageResizeUtil;
 import barcode.phomate.global.util.ImageTypeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -32,19 +27,13 @@ import java.util.*;
 @Transactional
 public class PhotoUploadService {
 
-    private final PhotoRepository photoRepository;
-    private final MemberRepository memberRepository;
-    private final S3StorageService s3StorageService;
-
-    private final AfterCommitExecutor afterCommitExecutor;
-    private final EmbeddingAsyncService embeddingAsyncService;
-
-    @Value("${app.cdn.base-url}")
-    private String cloudFrontBaseUrl;
+    private final PhotoRepository           photoRepository;
+    private final MemberRepository          memberRepository;
+    private final S3StorageService          s3StorageService;
+    private final PhotoCommitJobRepository  commitJobRepository;
 
     private static final long PRESIGNED_EXPIRE_SEC = 60 * 10; // 10min
-    private static final long MAX_FILE_SIZE_BYTES = 30L * 1024 * 1024; // 30MB
-    private static final String CACHE_CONTROL = "public, max-age=31536000";
+    private static final long MAX_FILE_SIZE_BYTES  = 30L * 1024 * 1024; // 30MB
 
     public PhotoUploadInitResponseDTO init(Long memberId, PhotoUploadInitRequestDTO request) {
         Member member = memberRepository.findById(memberId)
@@ -92,12 +81,25 @@ public class PhotoUploadService {
         return new PhotoUploadInitResponseDTO(results);
     }
 
+    /**
+     * Validates each item, verifies member ownership, creates one
+     * {@link PhotoCommitJob} per photo, and returns immediately.
+     * The actual S3 processing (download → resize → upload → embed)
+     * is handled asynchronously by {@link PhotoCommitJobPoller}.
+     *
+     * @param memberId ID of the authenticated member
+     * @param request  list of photos to commit; ignored when null or empty
+     * @return batch ID and the list of enqueued photo IDs
+     * @throws NotFoundException  if any photoId does not exist
+     * @throws ForbiddenException if any photo does not belong to {@code memberId}
+     */
     public PhotoUploadCommitResponseDTO commit(Long memberId, PhotoUploadCommitRequestDTO request) {
         if (request == null || request.items() == null || request.items().isEmpty()) {
-            return new PhotoUploadCommitResponseDTO(List.of());
+            return new PhotoUploadCommitResponseDTO(UUID.randomUUID().toString(), List.of());
         }
 
-        List<PhotoUploadCommitResultDTO> results = new ArrayList<>(request.items().size());
+        String batchId = UUID.randomUUID().toString();
+        List<Long> photoIds = new ArrayList<>(request.items().size());
 
         for (PhotoUploadCommitItemDTO item : request.items()) {
             validateCommitItem(item);
@@ -109,70 +111,19 @@ public class PhotoUploadService {
                 throw new ForbiddenException("권한이 없습니다.");
             }
 
-            HeadObjectResponse head = s3StorageService.headObject(item.originalKey());
+            commitJobRepository.save(PhotoCommitJob.builder()
+                    .batchId(batchId)
+                    .photoId(photo.getId())
+                    .memberId(memberId)
+                    .originalKey(item.originalKey())
+                    .etag(item.etag())
+                    .build());
 
-            if (item.etag() != null && !item.etag().isBlank()) {
-                String serverEtag = normalizeEtag(head.eTag());
-                String clientEtag = normalizeEtag(item.etag());
-
-                if (serverEtag != null && clientEtag != null && !serverEtag.equals(clientEtag)) {
-                    throw new IllegalStateException("ETag mismatch: 업로드된 파일이 다릅니다.");
-                }
-            }
-
-            byte[] originalBytes = s3StorageService.getObjectBytes(item.originalKey());
-
-            byte[] thumbJpg;
-            byte[] previewJpg;
-            try {
-                thumbJpg = ImageResizeUtil.toJpgResized(originalBytes, 320, 0.82f);
-                previewJpg = ImageResizeUtil.toJpgResized(originalBytes, 1080, 0.85f);
-            } catch (IOException e) {
-                throw new IllegalStateException("Failed to decode/resize image.", e);
-            }
-
-            String prefix = (photo.getImagePrefix() != null && !"TEMP".equals(photo.getImagePrefix()))
-                    ? photo.getImagePrefix()
-                    : "photos/" + photo.getId();
-
-            long v = System.currentTimeMillis();
-            String thumbKey = prefix + "/t_" + v + ".jpg";
-            String previewKey = prefix + "/p_" + v + ".jpg";
-
-            s3StorageService.putBytes(thumbKey, thumbJpg, "image/jpeg", CACHE_CONTROL);
-            s3StorageService.putBytes(previewKey, previewJpg, "image/jpeg", CACHE_CONTROL);
-
-            photo.updateImageKeys(prefix, item.originalKey(), thumbKey, previewKey);
-
-            String previewUrl = cloudFrontBaseUrl + "/" + previewKey;
-
-            Long createdAtMs = photo.getCreatedAt()
-                    .atZone(ZoneId.systemDefault())
-                    .toInstant()
-                    .toEpochMilli();
-
-            String textForEmbedding = (photo.getDescription() == null) ? "" : photo.getDescription().trim();
-
-            EmbedRequestDTO reqDto = new EmbedRequestDTO(
-                    photo.getId(),
-                    memberId,
-                    previewUrl,
-                    textForEmbedding,
-                    createdAtMs
-            );
-
-            afterCommitExecutor.run(() -> {
-                try {
-                    embeddingAsyncService.embedPhoto(reqDto);
-                } catch (Exception e) {
-                    log.error("[EMBED] enqueue failed photoId={} err={}", photo.getId(), e.getMessage(), e);
-                }
-            });
-
-            results.add(new PhotoUploadCommitResultDTO(photo.getId(), previewUrl));
+            photoIds.add(photo.getId());
         }
 
-        return new PhotoUploadCommitResponseDTO(results);
+        log.info("[COMMIT] enqueued batchId={} count={}", batchId, photoIds.size());
+        return new PhotoUploadCommitResponseDTO(batchId, photoIds);
     }
 
     private void validateInitItem(PhotoUploadInitItemDTO item) {
@@ -212,12 +163,4 @@ public class PhotoUploadService {
         return LocalDateTime.now();
     }
 
-    private String normalizeEtag(String etag) {
-        if (etag == null) return null;
-        String t = etag.trim();
-        if (t.startsWith("\"") && t.endsWith("\"") && t.length() >= 2) {
-            t = t.substring(1, t.length() - 1);
-        }
-        return t.isBlank() ? null : t;
-    }
 }

--- a/src/main/java/barcode/phomate/domain/photo/domain/entity/PhotoCommitJob.java
+++ b/src/main/java/barcode/phomate/domain/photo/domain/entity/PhotoCommitJob.java
@@ -1,0 +1,156 @@
+package barcode.phomate.domain.photo.domain.entity;
+
+import barcode.phomate.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a single-photo commit job enqueued by the upload commit endpoint.
+ *
+ * <p>One job corresponds to one photo. Multiple jobs sharing the same
+ * {@code batchId} belong to the same commit request.
+ *
+ * <p>Status transitions:
+ * <pre>
+ *   PENDING → PROCESSING → DONE
+ *                        ↘ PENDING (retry, with back-off)
+ *                        ↘ FAILED  (retry_count ≥ maxRetries)
+ * </pre>
+ *
+ * <p>S3 keys for thumbnail and preview are derived deterministically from
+ * {@code photoId}, so re-processing simply overwrites the same objects.
+ */
+@Entity
+@Table(
+        name = "photo_commit_job",
+        indexes = {
+                @Index(name = "idx_pcj_status_next", columnList = "status, next_attempt_at"),
+                @Index(name = "idx_pcj_updated_at",  columnList = "updated_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhotoCommitJob extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Groups all jobs created from the same commit request. */
+    @Column(nullable = false, length = 36)
+    private String batchId;
+
+    /** FK to {@code photo.id}; the photo is pre-created by the init step. */
+    @Column(nullable = false)
+    private Long photoId;
+
+    /** Used to verify member ownership before processing. */
+    @Column(nullable = false)
+    private Long memberId;
+
+    /** Staging S3 key uploaded by the client; source for S3 download. */
+    @Column(nullable = false, length = 512)
+    private String originalKey;
+
+    /**
+     * ETag supplied by the client for integrity verification.
+     * Nullable — verification is skipped when blank.
+     */
+    @Column(length = 255)
+    private String etag;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private PhotoCommitJobStatus status;
+
+    /** Number of processing attempts already made. Starts at 0. */
+    @Column(nullable = false)
+    private int retryCount;
+
+    /**
+     * Earliest time at which the poller may pick up this job.
+     * Set to {@code now} on creation; advanced with exponential back-off on retry.
+     */
+    @Column(nullable = false)
+    private LocalDateTime nextAttemptAt;
+
+    /**
+     * Truncated error message from the most recent failed attempt.
+     * Null when the job has never failed.
+     */
+    @Column(columnDefinition = "TEXT")
+    private String lastError;
+
+    @Builder
+    public PhotoCommitJob(String batchId,
+                          Long photoId,
+                          Long memberId,
+                          String originalKey,
+                          String etag) {
+        this.batchId       = batchId;
+        this.photoId       = photoId;
+        this.memberId      = memberId;
+        this.originalKey   = originalKey;
+        this.etag          = etag;
+        this.status        = PhotoCommitJobStatus.PENDING;
+        this.retryCount    = 0;
+        this.nextAttemptAt = LocalDateTime.now();
+    }
+
+    // ── State transitions ────────────────────────────────────────────────────
+
+    /** Moves the job into PROCESSING state. */
+    public void markProcessing() {
+        this.status = PhotoCommitJobStatus.PROCESSING;
+    }
+
+    /** Moves the job into DONE state and clears any previous error. */
+    public void markDone() {
+        this.status    = PhotoCommitJobStatus.DONE;
+        this.lastError = null;
+    }
+
+    /**
+     * Increments {@code retryCount} and either re-schedules (PENDING with
+     * exponential back-off) or permanently marks the job FAILED when
+     * {@code retryCount >= maxRetries}.
+     *
+     * @param errorMessage  human-readable cause; stored truncated to 1 000 chars
+     * @param maxRetries    total attempt limit before moving to FAILED; must be ≥ 1
+     * @param backoffBaseMs base delay in milliseconds; doubles each retry
+     */
+    public void scheduleRetry(String errorMessage, int maxRetries, long backoffBaseMs) {
+        this.retryCount++;
+        this.lastError = truncate(errorMessage, 1_000);
+
+        if (this.retryCount >= maxRetries) {
+            this.status = PhotoCommitJobStatus.FAILED;
+        } else {
+            // Exponential back-off: base * 2^(retryCount-1)
+            long delayMs = backoffBaseMs * (1L << (this.retryCount - 1));
+            this.status        = PhotoCommitJobStatus.PENDING;
+            this.nextAttemptAt = LocalDateTime.now().plusNanos(delayMs * 1_000_000L);
+        }
+    }
+
+    /**
+     * Resets a stuck PROCESSING job back to PENDING so the poller can retry it.
+     * Used by the stuck-sweep to recover jobs whose worker died mid-flight.
+     */
+    public void resetToPending() {
+        this.status        = PhotoCommitJobStatus.PENDING;
+        this.nextAttemptAt = LocalDateTime.now();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null) return null;
+        return s.length() <= maxLen ? s : s.substring(0, maxLen);
+    }
+}

--- a/src/main/java/barcode/phomate/domain/photo/domain/entity/PhotoCommitJobStatus.java
+++ b/src/main/java/barcode/phomate/domain/photo/domain/entity/PhotoCommitJobStatus.java
@@ -1,0 +1,12 @@
+package barcode.phomate.domain.photo.domain.entity;
+
+public enum PhotoCommitJobStatus {
+    /** Waiting to be picked up by the poller. */
+    PENDING,
+    /** Claimed by a poller; S3 processing is in progress. */
+    PROCESSING,
+    /** Thumbnail/preview upload and embedding trigger completed successfully. */
+    DONE,
+    /** Permanently failed after exhausting all retry attempts. */
+    FAILED
+}

--- a/src/main/java/barcode/phomate/domain/photo/domain/repository/PhotoCommitJobRepository.java
+++ b/src/main/java/barcode/phomate/domain/photo/domain/repository/PhotoCommitJobRepository.java
@@ -1,0 +1,55 @@
+package barcode.phomate.domain.photo.domain.repository;
+
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PhotoCommitJobRepository extends JpaRepository<PhotoCommitJob, Long> {
+
+    /**
+     * Selects up to {@code limit} PENDING jobs whose {@code next_attempt_at} is
+     * due, locks them with {@code FOR UPDATE SKIP LOCKED} to prevent concurrent
+     * pollers from claiming the same rows.
+     *
+     * <p><strong>Must be called within an active transaction.</strong>
+     *
+     * @param limit maximum number of rows to return; must be &gt; 0
+     * @return locked jobs in ascending {@code created_at} order
+     */
+    @Query(value = """
+            SELECT * FROM photo_commit_job
+            WHERE  status = 'PENDING'
+              AND  next_attempt_at <= NOW()
+            ORDER  BY created_at ASC
+            LIMIT  :limit
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    List<PhotoCommitJob> findPendingForUpdate(@Param("limit") int limit);
+
+    /**
+     * Selects up to {@code limit} PROCESSING jobs whose {@code updated_at} is
+     * older than {@code threshold}, locked with {@code FOR UPDATE SKIP LOCKED}.
+     * These are jobs whose worker died before completing.
+     *
+     * <p><strong>Must be called within an active transaction.</strong>
+     *
+     * @param threshold  cut-off time; jobs last updated before this are considered stuck
+     * @param limit      maximum number of rows to return; must be &gt; 0
+     * @return locked stuck jobs in ascending {@code updated_at} order
+     */
+    @Query(value = """
+            SELECT * FROM photo_commit_job
+            WHERE  status = 'PROCESSING'
+              AND  updated_at < :threshold
+            ORDER  BY updated_at ASC
+            LIMIT  :limit
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    List<PhotoCommitJob> findStuckProcessingForUpdate(
+            @Param("threshold") LocalDateTime threshold,
+            @Param("limit") int limit);
+}

--- a/src/main/java/barcode/phomate/domain/photo/dto/PhotoUploadCommitResponseDTO.java
+++ b/src/main/java/barcode/phomate/domain/photo/dto/PhotoUploadCommitResponseDTO.java
@@ -2,6 +2,15 @@ package barcode.phomate.domain.photo.dto;
 
 import java.util.List;
 
+/**
+ * Response returned immediately when a commit request is accepted.
+ *
+ * @param batchId  UUID that groups all jobs created from this request;
+ *                 clients may use it to poll batch status in the future
+ * @param photoIds IDs of the photos whose processing jobs have been enqueued;
+ *                 order matches the order of items in the request
+ */
 public record PhotoUploadCommitResponseDTO(
-        List<PhotoUploadCommitResultDTO> items
+        String batchId,
+        List<Long> photoIds
 ) {}

--- a/src/test/java/barcode/phomate/domain/photo/application/PhotoCommitJobPollerTest.java
+++ b/src/test/java/barcode/phomate/domain/photo/application/PhotoCommitJobPollerTest.java
@@ -1,0 +1,108 @@
+package barcode.phomate.domain.photo.application;
+
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJob;
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJobStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PhotoCommitJobPollerTest {
+
+    @Mock PhotoCommitJobService jobService;
+
+    @InjectMocks PhotoCommitJobPoller poller;
+
+    // ── poll ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void poll_WhenNoPendingJobs_DoesNotCallProcessOne() {
+        // Given
+        given(jobService.claimPending(anyInt())).willReturn(List.of());
+
+        // When
+        poller.poll();
+
+        // Then
+        then(jobService).should(never()).processOne(any());
+    }
+
+    @Test
+    void poll_WhenPendingJobsExist_ProcessesEachJobById() {
+        // Given
+        PhotoCommitJob job1 = buildProcessingJob(1L);
+        PhotoCommitJob job2 = buildProcessingJob(2L);
+        given(jobService.claimPending(anyInt())).willReturn(List.of(job1, job2));
+
+        // When
+        poller.poll();
+
+        // Then — processOne called once per job, in order
+        then(jobService).should().processOne(1L);
+        then(jobService).should().processOne(2L);
+        then(jobService).shouldHaveNoMoreInteractions();
+    }
+
+    // ── sweepStuck ────────────────────────────────────────────────────────────
+
+    @Test
+    void sweepStuck_PassesThresholdOlderThan10Minutes() {
+        // Given
+        given(jobService.sweepStuck(any(), anyInt())).willReturn(0);
+        LocalDateTime before = LocalDateTime.now().minusMinutes(10);
+
+        // When
+        poller.sweepStuck();
+
+        // Then — threshold must be ≤ (now - 10 min)
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        then(jobService).should().sweepStuck(captor.capture(), anyInt());
+        assertThat(captor.getValue()).isBeforeOrEqualTo(before.plusSeconds(1));
+    }
+
+    @Test
+    void sweepStuck_WhenNoStuckJobs_DoesNotLog() {
+        // Given
+        given(jobService.sweepStuck(any(), anyInt())).willReturn(0);
+
+        // When / Then — no exception
+        poller.sweepStuck();
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a PhotoCommitJob stub that reports the given ID without DB interaction.
+     * Status is set to PROCESSING to simulate a claimed job.
+     */
+    private PhotoCommitJob buildProcessingJob(Long id) {
+        PhotoCommitJob job = PhotoCommitJob.builder()
+                .batchId("batch-test")
+                .photoId(id * 10)
+                .memberId(1L)
+                .originalKey("photos/" + id + "/o.jpg")
+                .etag("etag-" + id)
+                .build();
+        job.markProcessing();
+
+        // Inject id via reflection (field is private, set by JPA in prod)
+        try {
+            var field = PhotoCommitJob.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(job, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return job;
+    }
+}

--- a/src/test/java/barcode/phomate/domain/photo/application/PhotoCommitJobServiceTest.java
+++ b/src/test/java/barcode/phomate/domain/photo/application/PhotoCommitJobServiceTest.java
@@ -1,0 +1,158 @@
+package barcode.phomate.domain.photo.application;
+
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJob;
+import barcode.phomate.domain.photo.domain.entity.PhotoCommitJobStatus;
+import barcode.phomate.domain.photo.domain.repository.PhotoCommitJobRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PhotoCommitJobServiceTest {
+
+    @Mock PhotoCommitJobRepository repository;
+    @Mock PhotoCommitJobProcessor  processor;
+
+    @InjectMocks PhotoCommitJobService service;
+
+    private PhotoCommitJob pendingJob;
+
+    @BeforeEach
+    void setUp() {
+        pendingJob = PhotoCommitJob.builder()
+                .batchId("batch-1")
+                .photoId(10L)
+                .memberId(1L)
+                .originalKey("photos/10/o_abc.jpg")
+                .etag("etag-val")
+                .build();
+    }
+
+    // ── claimPending ──────────────────────────────────────────────────────────
+
+    @Test
+    void claimPending_WhenPendingJobsExist_MarksThemProcessing() {
+        // Given
+        given(repository.findPendingForUpdate(5)).willReturn(List.of(pendingJob));
+
+        // When
+        List<PhotoCommitJob> claimed = service.claimPending(5);
+
+        // Then
+        assertThat(claimed).hasSize(1);
+        assertThat(claimed.get(0).getStatus()).isEqualTo(PhotoCommitJobStatus.PROCESSING);
+    }
+
+    @Test
+    void claimPending_WhenNoPendingJobs_ReturnsEmptyList() {
+        // Given
+        given(repository.findPendingForUpdate(anyInt())).willReturn(List.of());
+
+        // When
+        List<PhotoCommitJob> claimed = service.claimPending(10);
+
+        // Then
+        assertThat(claimed).isEmpty();
+        then(processor).shouldHaveNoInteractions();
+    }
+
+    // ── processOne ────────────────────────────────────────────────────────────
+
+    @Test
+    void processOne_WhenProcessingSucceeds_MarksJobDone() {
+        // Given
+        pendingJob.markProcessing();
+        given(repository.findById(1L)).willReturn(Optional.of(pendingJob));
+        willDoNothing().given(processor).process(pendingJob);
+
+        // When
+        service.processOne(1L);
+
+        // Then
+        assertThat(pendingJob.getStatus()).isEqualTo(PhotoCommitJobStatus.DONE);
+        assertThat(pendingJob.getLastError()).isNull();
+    }
+
+    @Test
+    void processOne_WhenProcessingFailsAndRetriesRemaining_SchedulesRetry() {
+        // Given
+        pendingJob.markProcessing();
+        given(repository.findById(1L)).willReturn(Optional.of(pendingJob));
+        willThrow(new RuntimeException("S3 error")).given(processor).process(pendingJob);
+
+        // When
+        service.processOne(1L);
+
+        // Then  — retryCount=1 < MAX_RETRIES=3 → still PENDING
+        assertThat(pendingJob.getStatus()).isEqualTo(PhotoCommitJobStatus.PENDING);
+        assertThat(pendingJob.getRetryCount()).isEqualTo(1);
+        assertThat(pendingJob.getLastError()).contains("S3 error");
+        assertThat(pendingJob.getNextAttemptAt()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    void processOne_WhenProcessingFailsAndNoRetriesRemaining_MarksJobFailed() {
+        // Given — exhaust retries up to the threshold
+        pendingJob.markProcessing();
+        pendingJob.scheduleRetry("err", PhotoCommitJobService.MAX_RETRIES, PhotoCommitJobService.BACKOFF_BASE_MS);
+        // scheduleRetry increments retryCount to 1 → still PENDING with retryCount=1
+        // force retryCount to MAX_RETRIES-1 so next failure tips over
+        for (int i = pendingJob.getRetryCount(); i < PhotoCommitJobService.MAX_RETRIES - 1; i++) {
+            pendingJob.scheduleRetry("err", PhotoCommitJobService.MAX_RETRIES, PhotoCommitJobService.BACKOFF_BASE_MS);
+        }
+        pendingJob.markProcessing();
+
+        given(repository.findById(99L)).willReturn(Optional.of(pendingJob));
+        willThrow(new RuntimeException("fatal")).given(processor).process(pendingJob);
+
+        // When
+        service.processOne(99L);
+
+        // Then
+        assertThat(pendingJob.getStatus()).isEqualTo(PhotoCommitJobStatus.FAILED);
+        assertThat(pendingJob.getRetryCount()).isEqualTo(PhotoCommitJobService.MAX_RETRIES);
+        assertThat(pendingJob.getLastError()).contains("fatal");
+    }
+
+    // ── sweepStuck ────────────────────────────────────────────────────────────
+
+    @Test
+    void sweepStuck_WhenStuckJobsExist_ResetsThemToPending() {
+        // Given
+        pendingJob.markProcessing();
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        given(repository.findStuckProcessingForUpdate(eq(threshold), anyInt()))
+                .willReturn(List.of(pendingJob));
+
+        // When
+        int recovered = service.sweepStuck(threshold, 50);
+
+        // Then
+        assertThat(recovered).isEqualTo(1);
+        assertThat(pendingJob.getStatus()).isEqualTo(PhotoCommitJobStatus.PENDING);
+    }
+
+    @Test
+    void sweepStuck_WhenNoStuckJobs_ReturnsZero() {
+        // Given
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        given(repository.findStuckProcessingForUpdate(any(), anyInt())).willReturn(List.of());
+
+        // When
+        int recovered = service.sweepStuck(threshold, 50);
+
+        // Then
+        assertThat(recovered).isZero();
+    }
+}


### PR DESCRIPTION
## 📝 PR 유형

- [x] ♻️ refactor: 코드 리팩토링

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->
close #87 

## ✅ 작업 목록

- [x] : PhotoCommitJob 엔티티 및 리포지토리 추가 (PENDING/PROCESSING/DONE/FAILED, FOR UPDATE SKIP LOCKED)
- [x] : POST /api/photos/upload/commit → 잡 등록 + 즉시 batchId 반환으로 전환
- [x] : 기존 S3 처리 로직을 PhotoCommitJobProcessor로 추출 (REQUIRES_NEW 트랜잭션 격리)
- [x] : @Scheduled 폴러 구현 — 2초 주기 PENDING 처리, 60초 주기 스턱 스윕
- [x] : 지수 백오프 재시도 (기본 3회), 초과 시 FAILED 확정 + last_error 저장
- [x] : 단위 테스트 추가 (PhotoCommitJobService, PhotoCommitJobPoller)

## 🍰 논의사항

**트랜잭션 격리 구조**
processOne()(@Transactional) → processor.process()(@Transactional REQUIRES_NEW) 형태로 분리.
photo 작업이 실패해도 job 상태 업데이트(retry/FAILED)는 별도 트랜잭션으로 커밋되어 안전.

**멱등성**
썸네일·프리뷰 S3 키를 photos/{id}/t.jpg, photos/{id}/p.jpg로 고정(결정론적).
재처리 시 동일 키에 덮어쓰므로 중복 실행에 안전.

**스턱 스윕**
서버 재시작 등으로 PROCESSING 상태에서 멈춘 잡을 10분 후 PENDING으로 자동 복구.

**SQS 전환 고려**
PhotoCommitJobProcessor.process()는 순수 처리 로직만 담고 있어,
추후 SQS consumer로 이식 시 해당 메서드를 그대로 재사용 가능.

## 📷 ETC